### PR TITLE
new parameter for setting the deletion of queryParamName from query

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -13,6 +13,7 @@ testData:
   removeHeadersOnSuccess: true
   queryParam: true
   queryParamName: token
+  removeQueryParamsOnSuccess: false
   pathSegment: true
   keys:
     - 83AB3503-50AA-4B57-9386-B9F0BADF2013

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -1,4 +1,4 @@
-﻿displayName: API Key Auth
+﻿displayName: API Key Auth RC
 type: middleware
 
 import: github.com/realCity/traefik-api-key-auth

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -1,7 +1,7 @@
 ﻿displayName: API Key Auth
 type: middleware
 
-import: github.com/Septima/traefik-api-key-auth
+import: github.com/realCity/traefik-api-key-auth
 
 summary: "Authorise API requests with an API Key"
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Septima/traefik-api-key-auth
+module github.com/realCity/traefik-api-key-auth
 
 go 1.19

--- a/plugin.go
+++ b/plugin.go
@@ -18,7 +18,7 @@ type Config struct {
 	QueryParam                 bool     `json:"queryParam,omitempty"`
 	QueryParamName             string   `json:"queryParamName,omitempty"`
 	PathSegment                bool     `json:"pathSegment,omitempty"`
-	removeQueryParamsOnSuccess bool		`json:"removeQueryParamsOnSuccess,omitempty"`
+	RemoveQueryParamsOnSuccess bool		`json:"removeQueryParamsOnSuccess,omitempty"`
 	Keys                       []string `json:"keys,omitempty"`
 	RemoveHeadersOnSuccess     bool     `json:"removeHeadersOnSuccess,omitempty"`
 	InternalForwardHeaderName  string   `json:"internalForwardHeaderName,omitempty"`
@@ -39,7 +39,7 @@ func CreateConfig() *Config {
 		QueryParam:                true,
 		QueryParamName:            "token",
 		PathSegment:               true,
-		removeQueryParamsOnSuccess:true,
+		RemoveQueryParamsOnSuccess:true,
 		Keys:                      make([]string, 0),
 		RemoveHeadersOnSuccess:    true,
 		InternalForwardHeaderName: "",
@@ -85,7 +85,7 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		queryParam:                 config.QueryParam,
 		queryParamName:             config.QueryParamName,
 		pathSegment:                config.PathSegment,
-		removeQueryParamsOnSuccess: config.removeQueryParamsOnSuccess,
+		removeQueryParamsOnSuccess: config.RemoveQueryParamsOnSuccess,
 		keys:                       config.Keys,
 		removeHeadersOnSuccess:     config.RemoveHeadersOnSuccess,
 		internalForwardHeaderName:  config.InternalForwardHeaderName,
@@ -171,7 +171,7 @@ func (ka *KeyAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		var matchedKey = contains(qs.Get(ka.queryParamName), ka.keys, true)
 		if matchedKey != "" {
 			if ka.removeQueryParamsOnSuccess{
-			qs.Del(ka.queryParamName)
+				qs.Del(ka.queryParamName)
 			}
 			req.URL.RawQuery = qs.Encode()
 			ka.ok(rw, req, matchedKey)


### PR DESCRIPTION
It's a config option, witch allows you to keep query parameter in the URL after a successful query parameter authentication. 